### PR TITLE
persists savedRecipe data

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -51,7 +51,11 @@ const postData = (newRecipe: SingleRecipe) => {
   }
   
  const updateSavedRecipes = (userSpecificRecipes: SingleRecipe[]) => {
-  setSavedRecipes(savedRecipes => [...savedRecipes, ...userSpecificRecipes]);
+  setSavedRecipes(savedRecipes => {
+    const uniqueRecipes = [...new Set([...savedRecipes, ...userSpecificRecipes])];
+    return uniqueRecipes;
+  });
+  // setSavedRecipes(savedRecipes => [...savedRecipes, ...userSpecificRecipes]);
 };
 
   return (


### PR DESCRIPTION
## Necessary checkmarks:

    [] All Tests are Passing in all environments

    [x] The code will run locally

## Description of Change:

    description: The savedRecipe data persists now when we npm start the qpplication for that user. We may want to remove the savedRecipes button and logout on the log in page, and just keep the main logo for that page? There is a typescript error. Please take a look, if not, I can try to revisit it tonight. 
    
## Requested feedback: 
    
    Please check anything else, I will try to hop on and see when I get to my parents and then after dinner. Let me know if this is what you are looking for ?
